### PR TITLE
Include version in artifact creation with AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.1.{build}
+version: 1.2.{build}
 branches:
   only:
   - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ test_script:
 
         {
 
-            Write-Host "Found required '$($Path)' path for artifact creation.";
+            Write-Host "Found required '$($RequiredPath)' path for artifact creation.";
 
         }
 
@@ -39,11 +39,11 @@ test_script:
 
         {
 
-            Throw "Can't find required '$($Path)' path for artifact creation. $_";
+            Throw "Can't find required '$($RequiredPath)' path for artifact creation. $_";
 
         }
 
     }
 artifacts:
 - path: archive
-  name: $($env:APPVEYOR_PROJECT_NAME)-$($env:APPVEYOR_BUILD_VERSION)
+  name: $(appveyor_project_name)-$(appveyor_build_version)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ build_script:
 
     # script for colorizing diff output in Git Bash
 
-    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/git/git/master/contrib/diff-highlight/diff-highlight" -OutFile "archive\diff-highlight";
+    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/git/git/master/contrib/diff-highlight/diff-highlight" -OutFile "archive\bin\diff-highlight";
 test_script:
 - ps: >-
     # check existence of required directories for zip artifact creation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,27 +7,42 @@ install:
 build_script:
 - ps: >-
     # stage files (including submodules) in 'archive' directory for artifact creation
+
     git checkout-index -q -a --prefix="archive/";
+
     git submodule foreach 'git checkout-index -q -a --prefix="$toplevel/archive/$path/"';
 
     # create bin directory for script(s) to modify diff output in Git Bash
+
     New-Item -ItemType "Directory" -Path "archive\bin" | Out-Null;
 
     # script for colorizing diff output in Git Bash
+
     Invoke-WebRequest -Uri "https://raw.githubusercontent.com/git/git/master/contrib/diff-highlight/diff-highlight" -OutFile "archive\diff-highlight";
 test_script:
 - ps: >-
     # check existence of required directories for zip artifact creation
+
     ForEach ($RequiredPath in @( "archive", "archive\bin", "archive\.vim" ))
+
     {
+
         If (Test-Path -Path $RequiredPath -PathType Container)
+
         {
+
             Write-Host "Found required '$($Path)' path for artifact creation.";
+
         }
+
         Else
+
         {
+
             Throw "Can't find required '$($Path)' path for artifact creation. $_";
+
         }
+
     }
 artifacts:
 - path: archive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,46 +1,38 @@
 version: 1.1.{build}
 branches:
-      only:
-      - master
+  only:
+  - master
 install:
 - cmd: git submodule update -q --init
 build_script:
 - ps: >-
-    # stage files in 'latest' folder for zip artifact creation
+    # create bin directory for script(s) to modify diff output in Git Bash
 
-    git checkout-index -q -a --prefix="latest/";
-
-
-    # also stage files from submodules
-
-    git submodule foreach 'git checkout-index -q -a --prefix="$toplevel/latest/$path/"';
+    New-Item -ItemType "Directory" -Path "bin" | Out-Null;
 
 
-    # directory for script(s) to modify diff output in git bash
+    # script for colorizing diff output in Git Bash
 
-    New-Item -ItemType "Directory" -Path "latest\bin" | Out-Null;
-
-
-    # script for colorizing diff output in git bash
-
-    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/git/git/master/contrib/diff-highlight/diff-highlight" -OutFile "latest\bin\diff-highlight";
+    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/git/git/master/contrib/diff-highlight/diff-highlight" -OutFile "diff-highlight";
 test_script:
 - ps: >-
-    # check existence of path for zip artifact creation
+    # check existence of required top-level directories
 
-    $ArchivePath = "$($env:APPVEYOR_BUILD_FOLDER)\latest";
-
-    If (Test-Path -Path $ArchivePath -PathType Container)
+    ForEach ($RequiredPath in @( "bin", ".vim" )
 
     {
-        Write-Host "Found $($ArchivePath) for artifact creation.";
-    }
 
-    Else
+        If (Test-Path -Path $RequiredPath -PathType Container)
 
-    {
-        Throw "Can't find $($ArchivePath) path for artifact creation. $_";
-    }
+        {
+            Write-Host "Found required '$($Path)' path for release.";
+        }
+
+        Else
+
+        {
+            Throw "Can't find required '$($Path)' path for release. $_";
+        }
 artifacts:
-- path: latest
-  name: dotfiles-latest
+- path: .
+  name: $($env:APPVEYOR_PROJECT_NAME)-$($env:APPVEYOR_BUILD_VERSION)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,21 +18,27 @@ test_script:
 - ps: >-
     # check existence of required top-level directories
 
-    ForEach ($RequiredPath in @( "bin", ".vim" )
+    ForEach ($RequiredPath in @( "bin", ".vim" ))
 
     {
 
         If (Test-Path -Path $RequiredPath -PathType Container)
 
         {
+
             Write-Host "Found required '$($Path)' path for release.";
+
         }
 
         Else
 
         {
+
             Throw "Can't find required '$($Path)' path for release. $_";
+
         }
+
+    }
 artifacts:
 - path: .
   name: $($env:APPVEYOR_PROJECT_NAME)-$($env:APPVEYOR_BUILD_VERSION)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,39 +6,29 @@ install:
 - cmd: git submodule update -q --init
 build_script:
 - ps: >-
+    # stage files (including submodules) in 'archive' directory for artifact creation
+    git checkout-index -q -a --prefix="archive/";
+    git submodule foreach 'git checkout-index -q -a --prefix="$toplevel/archive/$path/"';
+
     # create bin directory for script(s) to modify diff output in Git Bash
-
-    New-Item -ItemType "Directory" -Path "bin" | Out-Null;
-
+    New-Item -ItemType "Directory" -Path "archive\bin" | Out-Null;
 
     # script for colorizing diff output in Git Bash
-
-    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/git/git/master/contrib/diff-highlight/diff-highlight" -OutFile "diff-highlight";
+    Invoke-WebRequest -Uri "https://raw.githubusercontent.com/git/git/master/contrib/diff-highlight/diff-highlight" -OutFile "archive\diff-highlight";
 test_script:
 - ps: >-
-    # check existence of required top-level directories
-
-    ForEach ($RequiredPath in @( "bin", ".vim" ))
-
+    # check existence of required directories for zip artifact creation
+    ForEach ($RequiredPath in @( "archive", "archive\bin", "archive\.vim" ))
     {
-
         If (Test-Path -Path $RequiredPath -PathType Container)
-
         {
-
-            Write-Host "Found required '$($Path)' path for release.";
-
+            Write-Host "Found required '$($Path)' path for artifact creation.";
         }
-
         Else
-
         {
-
-            Throw "Can't find required '$($Path)' path for release. $_";
-
+            Throw "Can't find required '$($Path)' path for artifact creation. $_";
         }
-
     }
 artifacts:
-- path: .
+- path: archive
   name: $($env:APPVEYOR_PROJECT_NAME)-$($env:APPVEYOR_BUILD_VERSION)


### PR DESCRIPTION
Change zip archive name from `dotfiles-latest.zip` to `dotfiles-<semver>.zip`, where `<semver>` is the major, minor, and build version assigned with AppVeyor.