### PR TITLE
Add rg alias for consistent separator in output.

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -4,3 +4,6 @@ cd ~
 # keystroke-saving aliases for commonly run commands
 alias ll="ls -lhA"
 alias ..="cd .."
+
+# rg alias for consistent separator when printing file paths
+alias rg='rg --path-separator="//"'


### PR DESCRIPTION
Add alias to `.bashrc` to default `rg` path separator to forward slash.
Done for consistency of path output when running `rg` from Git Bash on
Windows.

Fixes #8.