### PR TITLE
Change CI to build from all branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,4 @@
-version: 1.6.{build}
-branches:
-  only:
-  - master
+version: 1.7.0-{build}
 install:
 - cmd: git submodule update -q --init
 build_script:


### PR DESCRIPTION
Appveyor should build on commit to any branch, but increment the build
number instead of patch number. To support faster feedback from all
changes pushed to the repository, without impacting semantic version
used for release.