### PR TITLE
Add `.vimrc` entry to skip tab expand in makefiles

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -81,3 +81,6 @@ endif " has("autocmd")
 if has('syntax') && has('eval')
   packadd matchit
 endif
+
+" Prevent tab expansion for makefiles
+autocmd FileType make setlocal noexpandtab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 - This changelog ([#11])
+- `noexpandtab` to `.vimrc` for makefiles ([#12])
 
 ## Changed
 
@@ -10,6 +11,7 @@
 
 [#10]: https://github.com/beargle/dotfiles/pull/10
 [#11]: https://github.com/beargle/dotfiles/pull/11
+[#12]: https://github.com/beargle/dotfiles/pull/12
 
 # [1.6.0] (April 9, 2019)
 


### PR DESCRIPTION
Makefile default syntax uses a single `tab` character for indentation.
Usually we want to expand tabs to 4 spaces for consistent whitespace,
but prevent expansion when editing makefiles.